### PR TITLE
(feat): add "Keep Folder Structure" option for image export

### DIFF
--- a/convert-compress/App/Commands/AppCommands.swift
+++ b/convert-compress/App/Commands/AppCommands.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct AppCommands: Commands {
     @AppStorage(PreferencesStore.revealExportInFinder) private var revealExportInFinder = true
+    @AppStorage(PreferencesStore.keepFolderStructure) private var keepFolderStructure = false
     
     var body: some Commands {
         CommandGroup(after: .appSettings) {
@@ -9,6 +10,11 @@ struct AppCommands: Commands {
                 Label("Select Images after Export", systemImage: "folder")
             }
             .keyboardShortcut("r", modifiers: [.command, .shift])
+            
+            Toggle(isOn: $keepFolderStructure) {
+                Label("Keep Folder Structure", systemImage: "folder.badge.gearshape")
+            }
+            .keyboardShortcut("k", modifiers: [.command, .shift])
         }
     }
 }

--- a/convert-compress/Localizable.xcstrings
+++ b/convert-compress/Localizable.xcstrings
@@ -6003,6 +6003,126 @@
         }
       }
     },
+    "Keep Folder Structure" : {
+      "comment" : "Label for option to preserve the original folder hierarchy when exporting or processing images.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "احتفظ ببنية المجلد"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Behold mappestruktur"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ordnerstruktur beibehalten"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keep Folder Structure"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mantener la estructura de carpetas"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Säilytä kansiorakenne"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conserver la structure des dossiers"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mantieni la struttura delle cartelle"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フォルダー構造を保持"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "폴더 구조 유지"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Behold mappestruktur"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mapstructuur behouden"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zachowaj strukturę folderów"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Manter estrutura de pastas"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Manter estrutura de pastas"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сохранять структуру папок"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Behåll mappstruktur"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klasör yapısını koru"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保留文件夹结构"
+          }
+        }
+      }
+    },
     "Keep original format" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/convert-compress/Processing/Pipeline.swift
+++ b/convert-compress/Processing/Pipeline.swift
@@ -6,6 +6,7 @@ struct ProcessingPipeline {
     var operations: [ImageOperation] = []
     var removeMetadata: Bool = false
     var exportDirectory: URL? = nil
+    var folderStructureRoot: URL? = nil
     var finalFormat: ImageFormat? = nil
     var compressionPercent: Double? = nil
 
@@ -29,6 +30,9 @@ struct ProcessingPipeline {
 
         // Write into destination directory and atomically replace/move into place
         let destParent = plan.directory
+        if !FileManager.default.fileExists(atPath: destParent.path) {
+            try FileManager.default.createDirectory(at: destParent, withIntermediateDirectories: true)
+        }
         guard let accessToken = SandboxAccessManager.shared.beginAccess(for: destParent) else {
             throw ImageOperationError.permissionDenied
         }
@@ -115,7 +119,19 @@ private extension ProcessingPipeline {
         let destinationURL: URL
         if let exportDir = exportDirectory {
             let base = currentURL.deletingPathExtension().lastPathComponent
-            destinationURL = exportDir.appendingPathComponent(base + "." + ext)
+            if let root = folderStructureRoot {
+                let assetDir = currentURL.deletingLastPathComponent().standardizedFileURL
+                let sourcePath = root.standardizedFileURL.path
+                let assetPath = assetDir.path
+                let relative = assetPath.hasPrefix(sourcePath)
+                    ? String(assetPath.dropFirst(sourcePath.count))
+                        .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+                    : ""
+                let targetDir = relative.isEmpty ? exportDir : exportDir.appendingPathComponent(relative)
+                destinationURL = targetDir.appendingPathComponent(base + "." + ext)
+            } else {
+                destinationURL = exportDir.appendingPathComponent(base + "." + ext)
+            }
         } else if isTempSource {
             let downloadsDir = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first ?? FileManager.default.homeDirectoryForCurrentUser
             let base = currentURL.deletingPathExtension().lastPathComponent

--- a/convert-compress/Services/Persistence/PreferencesStore.swift
+++ b/convert-compress/Services/Persistence/PreferencesStore.swift
@@ -2,5 +2,6 @@ import Foundation
 
 enum PreferencesStore {
     static let revealExportInFinder = "\(AppConstants.bundleIdentifier).reveal_export_in_finder"
+    static let keepFolderStructure = "\(AppConstants.bundleIdentifier).keep_folder_structure"
 }
 

--- a/convert-compress/Services/Processing/PipelineBuilder.swift
+++ b/convert-compress/Services/Processing/PipelineBuilder.swift
@@ -1,10 +1,11 @@
 import Foundation
 
 struct PipelineBuilder {
-    func build(configuration: ProcessingConfiguration, exportDirectory: URL?) -> ProcessingPipeline {
+    func build(configuration: ProcessingConfiguration, exportDirectory: URL?, folderStructureRoot: URL? = nil) -> ProcessingPipeline {
         var pipeline = ProcessingPipeline()
         pipeline.removeMetadata = configuration.removeMetadata
         pipeline.exportDirectory = exportDirectory
+        pipeline.folderStructureRoot = folderStructureRoot
         pipeline.finalFormat = configuration.selectedFormat
         pipeline.compressionPercent = configuration.compressionPercent
 

--- a/convert-compress/ViewModels/ImageToolsViewModel+Processing.swift
+++ b/convert-compress/ViewModels/ImageToolsViewModel+Processing.swift
@@ -4,9 +4,11 @@ import AppKit
 
 extension ImageToolsViewModel {
     func buildPipeline() -> ProcessingPipeline {
+        let keepStructure = UserDefaults.standard.bool(forKey: PreferencesStore.keepFolderStructure)
         let pipeline = PipelineBuilder().build(
             configuration: currentConfiguration,
-            exportDirectory: exportDirectory
+            exportDirectory: exportDirectory,
+            folderStructureRoot: keepStructure ? sourceDirectory : nil
         )
         if let fmt = selectedFormat { bumpRecentFormats(fmt) }
         return pipeline


### PR DESCRIPTION
- Introduced a new preference to preserve the original folder hierarchy during image export.
- Updated UI to include a toggle for this option in the app commands.
- Enhanced processing pipeline to support folder structure preservation when exporting images.
- Added localization for the new feature in multiple languages.