### PR TITLE
(feat): support for web urls paste and svg code

### DIFF
--- a/convert-compress/Processing/SVGImageLoader.swift
+++ b/convert-compress/Processing/SVGImageLoader.swift
@@ -37,6 +37,23 @@ struct SVGImageLoader: VectorImageLoader {
         return nil
     }
 
+    /// Detects SVG markup in a string and writes it to a temporary .svg file.
+    static func writeTempFile(from string: String) -> URL? {
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        let isSVG = trimmed.hasPrefix("<svg") || (trimmed.hasPrefix("<?xml") && trimmed.contains("<svg"))
+        guard isSVG, let data = trimmed.data(using: .utf8) else { return nil }
+        
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("paste_" + UUID().uuidString + ".svg")
+        
+        do {
+            try data.write(to: url)
+            return url
+        } catch {
+            return nil
+        }
+    }
+    
     // MARK: - Private Helpers
 
     private static func resolveIntrinsicSize(svgContent: String, nsImage: NSImage?) -> CGSize {

--- a/convert-compress/Services/Ingestion/IngestionCoordinator.swift
+++ b/convert-compress/Services/Ingestion/IngestionCoordinator.swift
@@ -83,10 +83,19 @@ enum IngestionCoordinator {
     /// - Returns: Array of image file URLs
     static func collectURLsFromPasteboard(_ pasteboard: NSPasteboard = .general) -> [URL] {
         if let urls = pasteboard.readObjects(forClasses: [NSURL.self], options: nil) as? [URL] {
-            return urls.flatMap { DirectoryEnumerator(url: $0).collectSupportedImages() }
+            let results = urls
+                .filter { $0.isFileURL }
+                .flatMap { DirectoryEnumerator(url: $0).collectSupportedImages() }
+            if !results.isEmpty { return results }
         }
         
-        if let images = pasteboard.readObjects(forClasses: [NSImage.self], options: nil) as? [NSImage] {
+        if let string = pasteboard.string(forType: .string),
+           let url = SVGImageLoader.writeTempFile(from: string) {
+            return [url]
+        }
+        
+        if let images = pasteboard.readObjects(forClasses: [NSImage.self], options: nil) as? [NSImage],
+           !images.isEmpty {
             return images.compactMap { writeTempPNG(from: $0) }
         }
         
@@ -234,22 +243,22 @@ enum IngestionCoordinator {
     // MARK: - Image Conversion
     
     /// Writes a temporary PNG file for the given NSImage.
-    /// - Parameters:
-    ///   - image: The image to convert
-    ///   - prefix: Filename prefix (default: "paste_")
-    /// - Returns: URL of the temporary PNG file, or nil if conversion failed
     private static func writeTempPNG(from image: NSImage, prefix: String = "paste_") -> URL? {
         guard let tiff = image.tiffRepresentation,
               let rep = NSBitmapImageRep(data: tiff),
-              let data = rep.representation(using: .png, properties: [:]) else {
+              let data = rep.representation(using: .png, properties: [:]),
+              !data.isEmpty else {
             return nil
         }
         
-        // Uses system /tmp which macOS cleans automatically
-        let url = URL(fileURLWithPath: "/tmp")
+        let url = FileManager.default.temporaryDirectory
             .appendingPathComponent(prefix + UUID().uuidString + ".png")
         
-        try? data.write(to: url)
-        return url
+        do {
+            try data.write(to: url)
+            return url
+        } catch {
+            return nil
+        }
     }
 } 


### PR DESCRIPTION
- Implemented a method to detect SVG markup in a string and write it to a temporary .svg file.
- Updated the pasteboard URL collection to include SVG data handling, allowing for SVG files to be created from string input.
- Enhanced the temporary PNG file writing process to ensure data integrity before writing to disk.