### PR TITLE
(feat): add AVIF encoding support

### DIFF
--- a/convert-compress.xcodeproj/project.pbxproj
+++ b/convert-compress.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		B7438E642E7DA6F3003E7442 /* SDWebImageWebPCoder in Frameworks */ = {isa = PBXBuildFile; productRef = B7438E632E7DA6F3003E7442 /* SDWebImageWebPCoder */; };
+		B7D9FFF92F696EF00049799A /* SDWebImageAVIFCoder in Frameworks */ = {isa = PBXBuildFile; productRef = B7D9FFF82F696EF00049799A /* SDWebImageAVIFCoder */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -69,6 +70,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B7D9FFF92F696EF00049799A /* SDWebImageAVIFCoder in Frameworks */,
 				B7438E642E7DA6F3003E7442 /* SDWebImageWebPCoder in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -123,6 +125,7 @@
 			name = "convert-compress";
 			packageProductDependencies = (
 				B7438E632E7DA6F3003E7442 /* SDWebImageWebPCoder */,
+				B7D9FFF82F696EF00049799A /* SDWebImageAVIFCoder */,
 			);
 			productName = "image-tools";
 			productReference = B7B69C582E83FC5700BE3883 /* convert-compress.app */;
@@ -226,6 +229,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				B7438E622E7DA6F3003E7442 /* XCRemoteSwiftPackageReference "SDWebImageWebPCoder" */,
+				B7D9FFF72F696EF00049799A /* XCRemoteSwiftPackageReference "SDWebImageAVIFCoder" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = B77ECCBB2E45573200C28347;
@@ -663,6 +667,14 @@
 				minimumVersion = 0.14.6;
 			};
 		};
+		B7D9FFF72F696EF00049799A /* XCRemoteSwiftPackageReference "SDWebImageAVIFCoder" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/SDWebImage/SDWebImageAVIFCoder";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.12.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -670,6 +682,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = B7438E622E7DA6F3003E7442 /* XCRemoteSwiftPackageReference "SDWebImageWebPCoder" */;
 			productName = SDWebImageWebPCoder;
+		};
+		B7D9FFF82F696EF00049799A /* SDWebImageAVIFCoder */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B7D9FFF72F696EF00049799A /* XCRemoteSwiftPackageReference "SDWebImageAVIFCoder" */;
+			productName = SDWebImageAVIFCoder;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/convert-compress.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/convert-compress.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,33 @@
 {
-  "originHash" : "fc67a751f36b65096325f2b11a4575605006997b7b439bfca86ad77f13498166",
+  "originHash" : "165a933d696b0a58aa429639c931cce04cce63a2bbca2bfbc8aa2f01fab9997c",
   "pins" : [
+    {
+      "identity" : "libaom-xcode",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SDWebImage/libaom-Xcode.git",
+      "state" : {
+        "revision" : "b00c20d10f13608c7579aad1f849e0f815d4d3a8",
+        "version" : "3.0.0"
+      }
+    },
+    {
+      "identity" : "libavif-xcode",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SDWebImage/libavif-Xcode.git",
+      "state" : {
+        "revision" : "0dc978b08b9bf8b7d1b505f1cb15218e8f637a6c",
+        "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "libvmaf-xcode",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SDWebImage/libvmaf-Xcode.git",
+      "state" : {
+        "revision" : "41db5dc11d05c02d1aca7de0b572a068f528c37c",
+        "version" : "2.3.1"
+      }
+    },
     {
       "identity" : "libwebp-xcode",
       "kind" : "remoteSourceControl",
@@ -20,12 +47,21 @@
       }
     },
     {
+      "identity" : "sdwebimageavifcoder",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SDWebImage/SDWebImageAVIFCoder",
+      "state" : {
+        "revision" : "b6455e16f2752d43e05d58ffbe38aac56e7c1149",
+        "version" : "0.12.0"
+      }
+    },
+    {
       "identity" : "sdwebimagewebpcoder",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SDWebImage/SDWebImageWebPCoder.git",
       "state" : {
-        "revision" : "f534cfe830a7807ecc3d0332127a502426cfa067",
-        "version" : "0.14.6"
+        "revision" : "12d83edbcc795fb7b5c0c3cb74d739108d3357d2",
+        "version" : "0.15.0"
       }
     }
   ],

--- a/convert-compress/Processing/Encoder/AVIFEncoder.swift
+++ b/convert-compress/Processing/Encoder/AVIFEncoder.swift
@@ -1,0 +1,68 @@
+import Foundation
+import AppKit
+import UniformTypeIdentifiers
+import libavif
+
+struct AVIFEncoder: CustomImageEncoder {
+    func canEncode(utType: UTType) -> Bool {
+        utType == .avif
+    }
+
+    func encode(cgImage: CGImage, pixelSize: CGSize, utType: UTType, compressionQuality: Double?, stripMetadata: Bool) throws -> Data {
+        let width = cgImage.width
+        let height = cgImage.height
+        let bytesPerRow = width * 4
+
+        let pixels = UnsafeMutablePointer<UInt8>.allocate(capacity: height * bytesPerRow)
+        defer { pixels.deallocate() }
+
+        guard let ctx = CGContext(
+            data: pixels,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: bytesPerRow,
+            space: CGColorSpace(name: CGColorSpace.sRGB)!,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
+            throw ImageOperationError.exportFailed
+        }
+        ctx.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+        guard let avifImage = avifImageCreate(UInt32(width), UInt32(height), 8, AVIF_PIXEL_FORMAT_YUV444) else {
+            throw ImageOperationError.exportFailed
+        }
+        defer { avifImageDestroy(avifImage) }
+
+        var rgb = avifRGBImage()
+        avifRGBImageSetDefaults(&rgb, avifImage)
+        rgb.format = AVIF_RGB_FORMAT_RGBA
+        rgb.depth = 8
+        rgb.alphaPremultiplied = 1
+        rgb.pixels = pixels
+        rgb.rowBytes = UInt32(bytesPerRow)
+        avifImageRGBToYUV(avifImage, &rgb)
+
+        guard let encoder = avifEncoderCreate() else {
+            throw ImageOperationError.exportFailed
+        }
+        defer { avifEncoderDestroy(encoder) }
+
+        let quality = Int32((compressionQuality ?? 0.9) * 100)
+        encoder.pointee.speed = 6
+        encoder.pointee.maxThreads = Int32(min(ProcessInfo.processInfo.activeProcessorCount, 8))
+        encoder.pointee.quality = quality
+        encoder.pointee.qualityAlpha = quality
+
+        var raw = avifRWData(data: nil, size: 0)
+        let result = avifEncoderWrite(encoder, avifImage, &raw)
+        guard result == AVIF_RESULT_OK else {
+            if raw.data != nil { avifRWDataFree(&raw) }
+            throw ImageOperationError.exportFailed
+        }
+
+        let data = Data(bytes: raw.data!, count: raw.size)
+        avifRWDataFree(&raw)
+        return data
+    }
+}

--- a/convert-compress/Processing/Encoder/CustomImageEncoder.swift
+++ b/convert-compress/Processing/Encoder/CustomImageEncoder.swift
@@ -9,7 +9,8 @@ protocol CustomImageEncoder {
 
 struct CustomImageEncoderRegistry {
     private static let encoders: [CustomImageEncoder] = [
-        WebPEncoder()
+        WebPEncoder(),
+        AVIFEncoder()
     ]
 
     static func encoder(for utType: UTType) -> CustomImageEncoder? {

--- a/convert-compress/Utils/ImageIOCapabilities.swift
+++ b/convert-compress/Utils/ImageIOCapabilities.swift
@@ -26,6 +26,10 @@ final class ImageIOCapabilities {
         // ImageIO may not advertise WebP as a destination type on all systems
         self.writableTypes.insert(UTType.webP.identifier)
 
+        // Ensure AVIF appears as readable + writable via SDWebImageAVIFCoder
+        self.readableTypes.insert(UTType.avif.identifier)
+        self.writableTypes.insert(UTType.avif.identifier)
+
         for utType in VectorImageSupport.allSupportedUTTypes {
             self.readableTypes.insert(utType.identifier)
         }
@@ -67,9 +71,10 @@ final class ImageIOCapabilities {
             UTType.png.identifier: 1,
             UTType.heic.identifier: 2,
             UTType.webP.identifier: 3,
-            UTType.tiff.identifier: 4,
-            UTType.bmp.identifier: 5,
-            UTType.gif.identifier: 6
+            UTType.avif.identifier: 4,
+            UTType.tiff.identifier: 5,
+            UTType.bmp.identifier: 6,
+            UTType.gif.identifier: 7
         ]
         return results.sorted { a, b in
             let ai = priority[a.utType.identifier] ?? Int.max
@@ -87,8 +92,8 @@ final class ImageIOCapabilities {
     func capabilities(forUTType utType: UTType) -> FormatCapabilities {
         let isReadable = supportsReading(utType: utType)
         let isWritable = supportsWriting(utType: utType)
-        let supportsQuality = (utType == .jpeg) || (utType == UTType.heic) || (utType == UTType.webP)
-        let supportsLossless = (utType == .png) || (utType == .tiff) || (utType == .bmp) || (utType == .gif) || (utType == UTType.webP)
+        let supportsQuality = (utType == .jpeg) || (utType == UTType.heic) || (utType == UTType.webP) || (utType == .avif)
+        let supportsLossless = (utType == .png) || (utType == .tiff) || (utType == .bmp) || (utType == .gif) || (utType == UTType.webP) || (utType == .avif)
         let supportsMetadata = supportsPrivacySensitiveMetadata(utType: utType)
         let supportsAlpha = supportsAlphaChannel(utType: utType)
         let resizeRestricted = sizeRestrictions(forUTType: utType) != nil
@@ -145,7 +150,7 @@ final class ImageIOCapabilities {
 
     // MARK: - Alpha channel support
     private func supportsAlphaChannel(utType: UTType) -> Bool {
-        if utType == .png || utType == .tiff || utType == .gif || utType == UTType.heic || utType == UTType.heif || utType == UTType.webP || utType == .bmp || utType == .icns { // BMP can have alpha in some variants; be permissive
+        if utType == .png || utType == .tiff || utType == .gif || utType == UTType.heic || utType == UTType.heif || utType == UTType.webP || utType == .avif || utType == .bmp || utType == .icns {
             return true
         }
         if utType == .jpeg { return false }

--- a/convert-compress/Utils/UTType+AVIF.swift
+++ b/convert-compress/Utils/UTType+AVIF.swift
@@ -1,0 +1,5 @@
+import UniformTypeIdentifiers
+
+extension UTType {
+    static let avif = UTType("public.avif")!
+}


### PR DESCRIPTION
- Introduced AVIFEncoder for encoding images in the AVIF format.
- Updated CustomImageEncoderRegistry to include AVIFEncoder.
- Enhanced ImageIOCapabilities to support AVIF as both readable and writable format.
- Added UTType extension for AVIF to facilitate type handling.
- Updated project dependencies to include SDWebImageAVIFCoder.